### PR TITLE
Allows change INSTALL_DIR and install without sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,11 @@ For Linux using custom installer:
 curl -sSL https://bit.ly/install-xq | sudo bash
 ```
 
+For Linux using custom installer, changing INSTALL_DIR, without sudo:
+```
+curl -sSL https://bit.ly/install-xq | INSTALL_DIR=$(pwd) bash
+```
+
 For Ubuntu 22.10 or higher via package manager:
 ```
 apt-get install xq

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,7 +3,7 @@
 set -e
 
 URL_PREFIX="https://github.com/sibprogrammer/xq"
-INSTALL_DIR=/usr/local/bin/
+INSTALL_DIR=${INSTALL_DIR:-/usr/local/bin}
 BINARY=xq
 LATEST_VERSION=$(curl -L -s -H 'Accept: application/json' $URL_PREFIX/releases/latest | sed -e 's/.*"tag_name":"v\([^"]*\)".*/\1/')
 PLATFORM=$(uname -s | tr A-Z a-z)
@@ -28,7 +28,7 @@ ARCHIVE="${BINARY}_${LATEST_VERSION}_${PLATFORM}_${ARCH}.tar.gz"
 URL="$URL_PREFIX/releases/download/v${LATEST_VERSION}/$ARCHIVE"
 
 echo "Installation of $BINARY"
-rm -f $INSTALL_DIR$BINARY
-curl -sSL "$URL" | tar xz -C $INSTALL_DIR $BINARY
-chmod +x $INSTALL_DIR$BINARY
-echo "Successfully installed at $INSTALL_DIR$BINARY"
+rm -f $INSTALL_DIR/$BINARY
+curl -sSL "$URL" | tar xz -C $INSTALL_DIR/ $BINARY
+chmod +x $INSTALL_DIR/$BINARY
+echo "Successfully installed at $INSTALL_DIR/$BINARY"


### PR DESCRIPTION
This feature is useful for installing `xq` inside pipelines that do not have sudo permissions.