### PR TITLE
Fix panic formatting processing instructions without attributes

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -94,10 +94,16 @@ func FormatXml(reader io.Reader, writer io.Writer, indent string, colors int) er
 			_, _ = fmt.Fprintf(writer, "%s%s", tagColor("<?"), typedToken.Target)
 
 			pi := strings.TrimSpace(string(typedToken.Inst))
-			attrs := strings.Split(pi, " ")
-			for _, attr := range attrs {
-				attrComponents := strings.SplitN(attr, "=", 2)
-				_, _ = fmt.Fprintf(writer, " %s%s", attrComponents[0], attrColor("="+attrComponents[1]))
+			if pi != "" {
+				attrs := strings.Split(pi, " ")
+				for _, attr := range attrs {
+					attrComponents := strings.SplitN(attr, "=", 2)
+					if len(attrComponents) == 2 {
+						_, _ = fmt.Fprintf(writer, " %s%s", attrComponents[0], attrColor("="+attrComponents[1]))
+					} else {
+						_, _ = fmt.Fprintf(writer, " %s", attrComponents[0])
+					}
+				}
 			}
 
 			_, _ = fmt.Fprint(writer, tagColor("?>"), newline)

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -39,6 +39,7 @@ func TestFormatXml(t *testing.T) {
 		"unformatted14.xml": "formatted14.xml",
 		"unformatted15.xml": "formatted15.xml",
 		"unformatted16.xml": "formatted16.xml",
+		"unformatted17.xml": "formatted17.xml",
 	}
 
 	for unformattedFile, expectedFile := range files {

--- a/test/data/xml/formatted17.xml
+++ b/test/data/xml/formatted17.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet?>
+<?xml-stylesheet type="text/xsl" href="style.xsl"?>
+<rss>
+  <channel>
+    <title>Test</title>
+  </channel>
+</rss>

--- a/test/data/xml/unformatted17.xml
+++ b/test/data/xml/unformatted17.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet?>
+<?xml-stylesheet type="text/xsl" href="style.xsl"?>
+<rss><channel><title>Test</title></channel></rss>


### PR DESCRIPTION
## Problem

`xq` core-dumps when processing instructions other than `<?xml ...?>` have no pseudo-attributes (or any PI body lacking an `=`), e.g.:

```
$ { echo '<?xml version="1.0" encoding="UTF-8"?>'; echo '<?xml-stylesheet?>'; echo '<rss/>'; } | xq
<?xml version="1.0" encoding="UTF-8"?>
<?xml-stylesheetpanic: runtime error: index out of range [1] with length 1
```

Fixes #193.

## Cause

In `FormatXml`, the `xml.ProcInst` branch split each pseudo-attribute on `=` and unconditionally read `attrComponents[1]`. An empty `Inst` (or one without `=`) yields a single-element slice, so the index panics.

## Fix

Skip an empty PI body and only emit the `=value` part when the split actually produced two components.

## Test plan

- Added `test/data/xml/unformatted17.xml` / `formatted17.xml` covering `<?xml-stylesheet?>` and `<?xml-stylesheet type="text/xsl" href="style.xsl"?>`, wired into `TestFormatXml`.
- `go test ./...` passes; the new case panics on master without this change.
- `go vet ./...` and `gofmt` clean.