### PR TITLE
Fix XPath boolean result output

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -243,6 +243,8 @@ func XPathQuery(reader io.Reader, writer io.Writer, query string, singleNode boo
 		switch typedVal := val.(type) {
 		case float64:
 			_, err = fmt.Fprintf(writer, "%.0f\n", typedVal)
+		case bool:
+			_, err = fmt.Fprintf(writer, "%t\n", typedVal)
 		case string:
 			_, err = fmt.Fprintf(writer, "%s\n", strings.TrimSpace(typedVal))
 		case *xpath.NodeIterator:

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -128,6 +128,21 @@ func TestXPathQuery(t *testing.T) {
 	}
 }
 
+func TestXPathQueryBoolean(t *testing.T) {
+	tests := map[string]string{
+		"boolean(//root)":    "true",
+		"boolean(//missing)": "false",
+	}
+
+	for query, expected := range tests {
+		output := new(strings.Builder)
+		options := QueryOptions{}
+		err := XPathQuery(strings.NewReader(`<?xml version="1.0"?><root></root>`), output, query, false, options)
+		assert.Nil(t, err)
+		assert.Equal(t, expected, strings.Trim(output.String(), "\n"))
+	}
+}
+
 func TestCSSQuery(t *testing.T) {
 	type test struct {
 		input  string


### PR DESCRIPTION
## Summary

Fixes XPath boolean query results.

## What changed

- Added regression coverage for `boolean(...)` XPath results.
- Updated `XPathQuery` to print boolean values instead of treating them as unknown result types.
- Preserved existing number, string, and node iterator output handling.

## Why

Issue #188 reports that `xq -x 'boolean(//root)'` fails with `unknown type error: true` instead of printing `true`.\n\n## Testing\n\n- `go test ./internal/utils -run TestXPathQueryBoolean`\n- `go test ./internal/utils`\n- `go test ./...`\n\nFixes #188